### PR TITLE
항상위로 고정한 상태에서 다른창 클릭했을때 테두리 안보이게하는 기능 추가

### DIFF
--- a/JHP/Api/Config.cs
+++ b/JHP/Api/Config.cs
@@ -13,6 +13,7 @@ namespace JHP.Api
             opacity = 100;
             sites = new List<Site>();
             topMost = false;
+            isHideWindowBorderOnFocusOut = false;
             alarmEnabled = new bool[] { false, false, false, false, false, false, false, false };
             alarmName = "";
             volume = 70;
@@ -27,7 +28,9 @@ namespace JHP.Api
         }
 
         [JsonConstructor]
-        public Config(int width, int height, int x, int y, int opacity, bool topMost, bool[] alarmEnabled, string alarmName, int volume, bool tts, List<Site> sites, CustomAlarm[] customAlarms, int rate)
+        public Config(int width, int height, int x, int y, int opacity, bool topMost, 
+            bool[] alarmEnabled, string alarmName, int volume, bool tts, 
+            List<Site> sites, CustomAlarm[] customAlarms, int rate, bool isHideWindowBorderOnFocusOut)
         {
             if (customAlarms == null)
             {
@@ -45,6 +48,7 @@ namespace JHP.Api
             this.opacity = opacity;
             this.sites = sites;
             this.topMost = topMost;
+            this.isHideWindowBorderOnFocusOut = isHideWindowBorderOnFocusOut;
             this.alarmEnabled = alarmEnabled;
             this.alarmName = alarmName;
             this.volume = volume;
@@ -91,6 +95,9 @@ namespace JHP.Api
         [JsonInclude]
         public bool topMost;
 
+        [JsonInclude] 
+        public bool isHideWindowBorderOnFocusOut;
+
         [JsonInclude]
         public bool[] alarmEnabled;
         [JsonInclude]
@@ -109,6 +116,7 @@ namespace JHP.Api
             this.y = c.y;
             this.opacity = c.opacity;
             this.topMost= c.topMost;
+            this.isHideWindowBorderOnFocusOut = c.isHideWindowBorderOnFocusOut;
             this.alarmEnabled = c.alarmEnabled;
             this.alarmName = c.alarmName;
             this.volume = c.volume;

--- a/JHP/Api/ToolStripCommand.cs
+++ b/JHP/Api/ToolStripCommand.cs
@@ -8,6 +8,6 @@ namespace JHP.Api
 {
     public enum ToolStripCommand
     {
-        ADD_SITE, TOPMOST
+        ADD_SITE, TOPMOST, TOGGLE_HIDE_WINDOW_BORDER
     }
 }

--- a/JHP/Form1.cs
+++ b/JHP/Form1.cs
@@ -36,14 +36,14 @@ namespace JHP
         private bool isWindowBorderHided = false;
         private string[] msg =
         {
-            "��ȹ��",
-            "60��",
-            "30��",
-            "20��",
-            "15��",
-            "10��",
-            "ȸ��",
-            "�Ŀ�ƾ",
+            "재획비",
+            "60분",
+            "30분",
+            "20분",
+            "15분",
+            "10분",
+            "회수",
+            "파운틴",
         };
 
         private void Timer_Tick(object? sender, EventArgs e)
@@ -276,13 +276,13 @@ namespace JHP
             menuStrip = new ContextMenuStrip();
             menuStrip.Items.Add(new ToolStripMenuItem()
             {
-                Text = "�׻� ���� ǥ��",
+                Text = "항상 위에 표시",
                 Tag = ToolStripCommand.TOPMOST,
                 Checked = Config.Instance.topMost
             });
             menuStrip.Items.Add(new ToolStripMenuItem()
             {
-                Text = "toggle hide window border on focus out",
+                Text = "다른 창 선택 시 테두리 안보이기",
                 Tag = ToolStripCommand.TOGGLE_HIDE_WINDOW_BORDER,
                 Checked = Config.Instance.isHideWindowBorderOnFocusOut
             });
@@ -301,7 +301,7 @@ namespace JHP
             menuStrip.Items.Add(new ToolStripSeparator());
             menuStrip.Items.Add(new ToolStripMenuItem()
             {
-                Text = "����Ʈ �߰�",
+                Text = "사이트 추가",
                 Tag = ToolStripCommand.ADD_SITE
             });
             menuStrip.ItemClicked += MenuStrip_ItemClicked;


### PR DESCRIPTION
안녕하세요! 프로그램 잘 쓰고 있습니다 감사합니다.

저는 노트북으로 재획을 하기도 하는데, 화면이 작아서 타이틀바나 테두리가 메이플을 조금 가리는것조차 아깝더라구요

그래서 창 고정한 상태로 메이플할때는 테두리와 타이틀바를 안보이게 하는 옵션을 추가했습니다.

확인부탁드려용